### PR TITLE
correct minor spelling mistakes

### DIFF
--- a/v5/csrf.md
+++ b/v5/csrf.md
@@ -5,7 +5,7 @@ Description: CSRF protection.
 
 ## Getting Started
 
-You can add CSRF protection to your site's forms by using the middleware `\App\Http\Middleware\VerifyNonce`. You will need to register the middleware to your `\App\Http\Kernel`. By default, it is apply to any request using the `http` group (controllers called by internal WordPress hooks have their own CSRF protections).
+You can add CSRF protection to your site's forms by using the middleware `\App\Http\Middleware\VerifyNonce`. You will need to register the middleware to your `\App\Http\Kernel`. By default, it is applied to any request using the `http` group (controllers called by internal WordPress hooks have their own CSRF protections).
 
 ```php
 class Kernel extends HttpKernel

--- a/v5/extension-rapid-pages.md
+++ b/v5/extension-rapid-pages.md
@@ -9,7 +9,7 @@ Description: Create static page caches to point your web server at for improved 
 
 TypeRocket's Rapid Pages extension allows you to take advantage of the `advanced-cache.php` WordPress drop-in. To enable Rapid Pages:
  
-1. Add the extension `\TypeRocketPro\Extensions\RapidPages` to your `app.extesnions` config setting.
+1. Add the extension `\TypeRocketPro\Extensions\RapidPages` to your `app.extensions` config setting.
 2. Run the galaxy command `php galaxy extension:publish typerocket/professional rapid-pages`.
 3. Add `define( 'WP_CACHE', true );` to your `wp-config.php` file.
 4. Add `define('TYPEROCKET_RAPID_PAGES_FOLDER_PATH', ABSPATH . 'tr_cache/rapid_cache');` to your `wp-config.php` file after `ABSPATH` is defined.

--- a/v5/install-via-composer.md
+++ b/v5/install-via-composer.md
@@ -86,9 +86,9 @@ In your browser, visit `localhost:8888` to view the WordPress install page.
 
 Running `root:install` will:
 
-- Downloads WordPress in the `wordpress` folder where the assets are located.
-- Creates the `wp-config.php` file in the main TypeRocket folder.
-- Enables TypeRocket's root theme as the default.
+- Download WordPress in the `wordpress` folder where the assets are located.
+- Create the `wp-config.php` file in the main TypeRocket folder.
+- Enable TypeRocket's root theme as the default.
 - Add `require __DIR__ . '/init.php';` to your `wp-config.php`.
 
 #### Deploying A Root Install

--- a/v5/models.md
+++ b/v5/models.md
@@ -27,7 +27,7 @@ Both `post` and `term` are unique and should be used with care. In many cases, i
 
 The `base` directive is the most useful and is for making a model that is connected to custom tables.
 
-*Note: The Galaxy command-line tool is not available if you are using the official TypeRocket Framework 4 WordPRess plugin.*
+*Note: The Galaxy command-line tool is not available if you are using the official TypeRocket Framework 4 WordPress plugin.*
 
 ### Command
 
@@ -156,7 +156,7 @@ $doc = (new Doc())->find(1);
 
 ## Fillable
 
-To limit the fields tht can be saved without being explicitly set, use the `$fillable` property.
+To limit the fields that can be saved without being explicitly set, use the `$fillable` property.
 
 ```php
 class Doc extends Model
@@ -728,7 +728,7 @@ $machines->toJson();
 
 ## Post Type Models
 
-At times will want to access the `WP_Post` object using a `WPPost` model without making an extra query to the database. You can now do this using the `WP_Post()` method on any post type model.
+At times you will want to access the `WP_Post` object using a `WPPost` model without making an extra query to the database. You can now do this using the `wpPost()` method on any post type model.
 
 Here is an advanced usage example on how this can be used to optimize your database performance.
 
@@ -744,7 +744,7 @@ class Symbol extends WPPost
 
     public function getLinkProperty()
     {
-        return get_the_permalink($this->WP_Post());
+        return get_the_permalink($this->wpPost());
     }
 
     public function getFeaturedImageProperty()

--- a/v5/policies.md
+++ b/v5/policies.md
@@ -7,7 +7,7 @@ Description: Policies give you expressive control over user action authorization
 
 Policies give you expressive control over user action authorization. For this reason, policies go hand-in-hand with WordPress roles and capabilities.
 
-For example, locate your `app/Auth/PostPilicy`.  
+For example, locate your `app/Auth/PostPolicy`.  
 
 ```php
 class PostPolicy extends Policy  

--- a/v5/post-types-theming.md
+++ b/v5/post-types-theming.md
@@ -31,7 +31,7 @@ tr_meta_box('Team Details')->apply($team)->setCallback(function() {
 tr_taxonomy('Department')->apply($team);
 ```
 
-Next, flush the rewrite rules in WordPress. This **VERY IMPORTANT**. Without flushing, rewrite rules, WordPress will not have a URL for the `person` post type.
+Next, flush the rewrite rules in WordPress. This is **VERY IMPORTANT**! Without flushing, rewrite rules, WordPress will not have a URL for the `person` post type.
 
 *Note: Flush rewrites by clicking Settings > Permalinks > Save Changes*
 

--- a/v5/relationships.md
+++ b/v5/relationships.md
@@ -13,7 +13,7 @@ In a [one to one](https://en.wikipedia.org/wiki/One-to-many_(data_model)) relati
 
 ### Implementation
 
-Take the plane flight example where one `Person` and have one `Seat`. For the `Person` model, let's assume there is a table named `wp_people` with the columns `id`, `name`, and `email`. For the `Seat` model lets assume there is a table named `wp_seats` with the columns `id`, `person_id`, `seat_number`, and `price`. How would you represent the database relationship in your TypeRocket models?
+Take the plane flight example where one `Person` has one `Seat`. For the `Person` model, let's assume there is a table named `wp_people` with the columns `id`, `name`, and `email`. For the `Seat` model lets assume there is a table named `wp_seats` with the columns `id`, `person_id`, `seat_number`, and `price`. How would you represent the database relationship in your TypeRocket models?
 
 Take a look at the `Person` model.
 


### PR DESCRIPTION
While reading the documentation I stumbled upon some minor spelling mistakes, which I corrected.

These fixes only apply to the latest docs (`v5`). While searching through the files, I noticed the other versions were also affected, but I didn't bother to change them. Shall I apply these corrections to all the other versions as well or are they considered outdated/deprecated?